### PR TITLE
remove the duplicated Docker section

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,3 @@ This is an early alpha release, best suited to developers. To install:
 * make
     
 A stand-alone version, useful for quick developer experiments, and <b><i>not</i></b> packaged up into a jupyter nbextension, is found in <i>./standalone/devel/</i>
-
-Docker Notes
-------------
-Kozo Nishida contributed a Dockerfile, very useful for secure and reproducible execution of a notebook.
-Here are my notes - an amalgam of Kozo's instructions, Mike Smoot's suggestions, and my own experiments:
-
-````
-docker build -t jupytercy .  # in repo's root directory, where Dockerfile is located
-docker images
-docker run -d -p 8888:8888 jupytercy
-docker ps   # reports the image name 
-docker exec -it <image name> jupyter notebook list
-````
-Now browse to the url reported by `docker exec`


### PR DESCRIPTION
I am sorry to bother you again.
This instruction is no longer required.

I'm asking @keiono to create an automated (Docker) build for this project on https://hub.docker.com/u/cytoscape/
